### PR TITLE
Remove unnecessary BrowserModule import

### DIFF
--- a/src/breadcrumbs.module.ts
+++ b/src/breadcrumbs.module.ts
@@ -1,7 +1,6 @@
 import {NgModule} from "@angular/core";
 import {BreadcrumbComponent} from "./breadcrumbs.component";
 import {RouterModule} from "@angular/router";
-import {BrowserModule} from "@angular/platform-browser";
 import {CommonModule} from "@angular/common";
 import {BreadcrumbsService} from "./breadcrumbs.service";
 
@@ -15,7 +14,6 @@ import {BreadcrumbsService} from "./breadcrumbs.service";
     ],
     imports: [
         RouterModule,
-        BrowserModule,
         CommonModule
     ],
     exports: [BreadcrumbComponent]


### PR DESCRIPTION
Remove to avoid the following error on lazy load modules:

 Error: BrowserModule has already been loaded. If you need access to common directives such as NgIf and NgFor from a lazy loaded module, import CommonModule instead.
Error: BrowserModule has already been loaded. If you need access to common directives such as NgIf and NgFor from a lazy loaded module, import CommonModule instead.